### PR TITLE
feature(asr-worker): expose available ASR models

### DIFF
--- a/.github/workflows/publish_asr_worker.yml
+++ b/.github/workflows/publish_asr_worker.yml
@@ -7,6 +7,33 @@ on:
       - 'asr-worker-*'
 
 jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: 3.12
+      ASTRAL_VERSION: 0.11.6
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create GH release
+        run: gh release create "$tag" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.ASTRAL_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+          working-directory: asr-worker
+      - name: Upload available models
+        run: |
+          uv run --frozen asr-worker models list-available > available-models.json
+          gh release upload "$tag" available-models.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+
   publish-io-worker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_asr_worker.yml
+++ b/.github/workflows/test_asr_worker.yml
@@ -24,6 +24,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: 3.12
+      ASTRAL_VERSION: 0.11.6
     steps:
       - uses: actions/checkout@v6
       - name: Setup Python project

--- a/.github/workflows/test_datashare_python.yml
+++ b/.github/workflows/test_datashare_python.yml
@@ -23,6 +23,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: 3.12
+      ASTRAL_VERSION: 0.11.6
     steps:
       - uses: actions/checkout@v6
       - name: Setup Python project

--- a/.github/workflows/test_translation_worker.yml
+++ b/.github/workflows/test_translation_worker.yml
@@ -23,6 +23,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: 3.12
+      ASTRAL_VERSION: 0.11.6
     steps:
       - uses: actions/checkout@v6
       - name: Setup Python project

--- a/.github/workflows/test_worker_template.yml
+++ b/.github/workflows/test_worker_template.yml
@@ -24,6 +24,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: 3.12
+      ASTRAL_VERSION: 0.11.6
     steps:
       - uses: actions/checkout@v6
       - name: Setup Python project

--- a/asr-worker/asr_worker/__main__.py
+++ b/asr-worker/asr_worker/__main__.py
@@ -1,0 +1,9 @@
+from .cli import cli_app
+
+
+def main() -> None:
+    cli_app()
+
+
+if __name__ == "__main__":
+    main()

--- a/asr-worker/asr_worker/cli/__init__.py
+++ b/asr-worker/asr_worker/cli/__init__.py
@@ -1,0 +1,35 @@
+from typing import Annotated
+
+import datashare_python
+import typer
+from datashare_python.cli import pretty_exc_callback, version_callback
+from datashare_python.cli.utils import AsyncTyper
+from icij_common.logging_utils import setup_loggers
+
+import asr_worker
+
+from .models import models_app
+
+cli_app = AsyncTyper(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    pretty_exceptions_enable=False,
+)
+cli_app.add_typer(models_app)
+
+
+@cli_app.callback()
+def main(
+    version: Annotated[  # noqa: ARG001
+        bool | None,
+        typer.Option("--version", callback=version_callback, is_eager=True),
+    ] = None,
+    *,
+    pretty_exceptions: Annotated[  # noqa: ARG001
+        bool,
+        typer.Option(
+            "--pretty-exceptions", callback=pretty_exc_callback, is_eager=True
+        ),
+    ] = False,
+) -> None:
+    """Datashare Python CLI."""
+    setup_loggers(["__main__", datashare_python.__name__, asr_worker.__name__])

--- a/asr-worker/asr_worker/cli/models.py
+++ b/asr-worker/asr_worker/cli/models.py
@@ -1,0 +1,13 @@
+from ..models import available_models
+from .utils import AsyncTyper
+
+_MODELS = "models"
+
+_LIST_AVAILABLE_MODELS_HELP = "list available ASR models by language"
+
+models_app = AsyncTyper(name=_MODELS)
+
+
+@models_app.async_command(help=_LIST_AVAILABLE_MODELS_HELP)
+async def list_available() -> None:
+    print(available_models().model_dump_json(indent=2))

--- a/asr-worker/asr_worker/cli/utils.py
+++ b/asr-worker/asr_worker/cli/utils.py
@@ -1,0 +1,35 @@
+import asyncio
+import concurrent.futures
+import sys
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+import typer
+
+
+class AsyncTyper(typer.Typer):
+    def async_command(self, *args, **kwargs) -> Callable[[Callable], Callable]:
+        def decorator(async_func: Callable) -> Callable:
+            @wraps(async_func)
+            def sync_func(*_args, **_kwargs) -> Any:
+                res = asyncio.run(async_func(*_args, **_kwargs))
+                return res
+
+            self.command(*args, **kwargs)(sync_func)
+            return async_func
+
+        return decorator
+
+
+def eprint(*args, **kwargs) -> None:
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def _to_concurrent(
+    fut: asyncio.Future, loop: asyncio.AbstractEventLoop
+) -> concurrent.futures.Future:
+    async def wait() -> None:
+        await fut
+
+    return asyncio.run_coroutine_threadsafe(wait(), loop)

--- a/asr-worker/asr_worker/models.py
+++ b/asr-worker/asr_worker/models.py
@@ -1,10 +1,11 @@
 import math
+from collections import defaultdict
+from functools import cache
 from typing import Annotated, Any, Self
 
 from caul.asr_pipeline import ASRPipelineConfig
 from caul.config import InferenceRunnerConfig as CaulInferenceRunnerConfig
-from caul.constant import ASRModel
-from caul.objects import ASRResult
+from caul.objects import ASRLanguage, ASRModel, ASRResult
 from caul.tasks import (
     ParakeetInferenceRunnerConfig,
     ParakeetPostprocessorConfig,
@@ -12,7 +13,7 @@ from caul.tasks import (
 )
 from datashare_python.objects import DatashareModel
 from icij_common.pydantic_utils import make_enum_discriminator, tagged_union
-from pydantic import Discriminator, Field
+from pydantic import Discriminator, Field, RootModel
 
 model_discriminator = make_enum_discriminator("model", ASRModel)
 InferenceRunnerConfig = Annotated[
@@ -75,3 +76,16 @@ class Transcription(DatashareModel):
         if confidence is not None:
             confidence = math.exp(asr_handler_result.score)
         return Transcription(confidence=confidence, transcripts=transcripts)
+
+
+AvailableModels = RootModel[dict[ASRLanguage, list[ASRModel]]]
+
+
+@cache
+def available_models() -> AvailableModels:
+    models = defaultdict(list)
+    for m in ASRModel:
+        for language in m.supported_languages():
+            models[language].append(m)
+    models = {k: sorted(v) for k, v in sorted(models.items())}
+    return AvailableModels.model_validate(models)

--- a/asr-worker/pyproject.toml
+++ b/asr-worker/pyproject.toml
@@ -21,7 +21,7 @@ asr-worker = "asr_worker.__main__:main"
 
 [project.optional-dependencies]
 cpu = [
-  "caul==0.3.0",
+  "caul==0.3.1",
   "torch==2.10.0",
   "torchaudio==2.10.0",
   "torchcodec==0.10.0",
@@ -32,14 +32,14 @@ gpu = [
   "torchcodec==0.10.0+cu128; sys_platform == 'linux'",
 ]
 inference = [
-  "caul[nemo]==0.3.0",
+  "caul[nemo]==0.3.1",
   "kaldialign==0.9.3",
   "ml-dtypes==0.5.4",
   "numpy==2.3.0",
   "pyarrow==20.0.0",
 ]
 preprocessing = [
-  "caul==0.3.0",
+  "caul==0.3.1",
 ]
 
 [project.entry-points."datashare.workflows"]

--- a/asr-worker/pyproject.toml
+++ b/asr-worker/pyproject.toml
@@ -16,9 +16,12 @@ dependencies = [
   "datashare-python~=0.5.0",
 ]
 
+[project.scripts]
+asr-worker = "asr_worker.__main__:main"
+
 [project.optional-dependencies]
 cpu = [
-  "caul==0.2.16",
+  "caul==0.3.0",
   "torch==2.10.0",
   "torchaudio==2.10.0",
   "torchcodec==0.10.0",
@@ -29,14 +32,14 @@ gpu = [
   "torchcodec==0.10.0+cu128; sys_platform == 'linux'",
 ]
 inference = [
-  "caul[nemo]==0.2.16",
+  "caul[nemo]==0.3.0",
   "kaldialign==0.9.3",
   "ml-dtypes==0.5.4",
   "numpy==2.3.0",
   "pyarrow==20.0.0",
 ]
 preprocessing = [
-  "caul==0.2.16",
+  "caul==0.3.0",
 ]
 
 [project.entry-points."datashare.workflows"]
@@ -90,6 +93,7 @@ torchcodec = [
   { index = "pytorch-cpu", extra = "cpu" },
 ]
 datashare-python = { path = "../datashare-python", editable = true }
+
 
 [tool.uv]
 package = true

--- a/asr-worker/tests/cli/test_asr_models.py
+++ b/asr-worker/tests/cli/test_asr_models.py
@@ -1,0 +1,17 @@
+from asr_worker.cli import cli_app
+from asr_worker.models import AvailableModels
+from typer.testing import CliRunner
+
+
+async def test_list_models(
+    typer_asyncio_patch,  # noqa: ANN001, ARG001
+) -> None:
+    # Given
+    runner = CliRunner(mix_stderr=False)
+    cmd = ["models", "list-available"]
+    # When
+    result = runner.invoke(cli_app, cmd, catch_exceptions=False)
+    # Then
+    assert int(result.exit_code) == 0
+    available_models = AvailableModels.model_validate_json(result.output)
+    assert isinstance(available_models.root, dict)

--- a/asr-worker/tests/conftest.py
+++ b/asr-worker/tests/conftest.py
@@ -15,6 +15,7 @@ from datashare_python.conftest import (  # noqa: F401
     test_es_client_session,
     test_temporal_client_session,
     test_worker_config,
+    typer_asyncio_patch,
     worker_lifetime_deps,
 )
 from datashare_python.dependencies import set_es_client, set_temporal_client

--- a/asr-worker/uv.dist.lock
+++ b/asr-worker/uv.dist.lock
@@ -218,9 +218,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "caul", marker = "extra == 'cpu'", specifier = "==0.2.16" },
-    { name = "caul", marker = "extra == 'preprocessing'", specifier = "==0.2.16" },
-    { name = "caul", extras = ["nemo"], marker = "extra == 'inference'", specifier = "==0.2.16" },
+    { name = "caul", marker = "extra == 'cpu'", specifier = "==0.3.0" },
+    { name = "caul", marker = "extra == 'preprocessing'", specifier = "==0.3.0" },
+    { name = "caul", extras = ["nemo"], marker = "extra == 'inference'", specifier = "==0.3.0" },
     { name = "datashare-python", specifier = "~=0.5.0" },
     { name = "kaldialign", marker = "extra == 'inference'", specifier = "==0.9.3" },
     { name = "ml-dtypes", marker = "extra == 'inference'", specifier = "==0.5.4" },
@@ -329,21 +329,23 @@ wheels = [
 
 [[package]]
 name = "caul"
-version = "0.2.16"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "icij-common", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "kaldialign", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
+    { name = "langcodes", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "numpy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchaudio", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-asr-worker-cpu') or (extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchaudio", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-asr-worker-cpu' and extra != 'extra-10-asr-worker-gpu') or (sys_platform == 'darwin' and extra == 'extra-10-asr-worker-gpu') or (sys_platform == 'darwin' and extra != 'extra-10-asr-worker-cpu') or (extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchaudio", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-asr-worker-cpu') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchaudio", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-asr-worker-gpu') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchcodec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/79/1ef53340a2c1fcc6b7f9e28182d8142b9e2806a9d54aaf2fa399f602701d/caul-0.2.16.tar.gz", hash = "sha256:9f5ac14b2cd721d3ac5d2d7e08fe495c851cb61acc51d634414efae2f68995a7", size = 319415, upload-time = "2026-04-10T08:08:23.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/61/68461e52702b359815a433a602ee85be940c2b65d144ec464bb95c95acd6/caul-0.3.0.tar.gz", hash = "sha256:0c4645b1466ead71f8535d75a20f6184c829933a1f3f921bdb11b47854145fb1", size = 326458, upload-time = "2026-04-17T08:02:49.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/42/8d6a1a6c42af5181f4ff12abf100052d01100f1be176808aab9e7930b0d6/caul-0.2.16-py3-none-any.whl", hash = "sha256:95f7d291e72dea39b56ce7c45d076dd8be0e80ee462f43840d296addea56a81e", size = 20621, upload-time = "2026-04-10T08:08:22.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/dc/73dbd87d99aab785e276d9cd0ee3ca6e43764eea00dd0b76476315047215/caul-0.3.0-py3-none-any.whl", hash = "sha256:278450d70881cce3eda714c4c8771d365209550be9eaf99bf085a55b2c4d0c27", size = 21796, upload-time = "2026-04-17T08:02:48.747Z" },
 ]
 
 [package.optional-dependencies]
@@ -1118,6 +1120,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/eb/5fcbbbf9a0e2c3a35effb88831a483345326bbc3a030a3b5b69aee647f84/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232", size = 59532, upload-time = "2026-03-09T13:15:47.047Z" },
     { url = "https://files.pythonhosted.org/packages/c3/9b/e17104555bb4db148fd52327feea1e96be4b88e8e008b029002c281a21ab/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a", size = 57420, upload-time = "2026-03-09T13:15:48.199Z" },
     { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892, upload-time = "2026-03-09T13:15:49.694Z" },
+]
+
+[[package]]
+name = "langcodes"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/75/f9edc5d72945019312f359e69ded9f82392a81d49c5051ed3209b100c0d2/langcodes-3.5.1.tar.gz", hash = "sha256:40bff315e01b01d11c2ae3928dd4f5cbd74dd38f9bd912c12b9a3606c143f731", size = 191084, upload-time = "2025-12-02T16:22:01.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/c1/d10b371bcba7abce05e2b33910e39c33cfa496a53f13640b7b8e10bb4d2b/langcodes-3.5.1-py3-none-any.whl", hash = "sha256:b6a9c25c603804e2d169165091d0cdb23934610524a21d226e4f463e8e958a72", size = 183050, upload-time = "2025-12-02T16:21:59.954Z" },
 ]
 
 [[package]]
@@ -2224,6 +2235,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycountry"
+version = "26.2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/061b9e7a48b85cfd69f33c33d2ef784a531c359399ad764243399673c8f5/pycountry-26.2.16.tar.gz", hash = "sha256:5b6027d453fcd6060112b951dd010f01f168b51b4bf8a1f1fc8c95c8d94a0801", size = 7711342, upload-time = "2026-02-17T03:42:52.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl", hash = "sha256:115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a", size = 8044600, upload-time = "2026-02-17T03:42:49.777Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2274,6 +2294,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/77/df8711ebb45910412f90d75198430fa1120f5618336b71fa00303601c5a4/pydantic_core-2.46.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1eae8d7d9b8c2a90b34d3d9014804dca534f7f40180197062634499412ea14e", size = 1953812, upload-time = "2026-04-13T09:05:40.293Z" },
     { url = "https://files.pythonhosted.org/packages/12/fe/14b35df69112bd812d6818a395eeab22eeaa2befc6f85bc54ed648430186/pydantic_core-2.46.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a95a2773680dd4b6b999d4eccdd1b577fd71c31739fb4849f6ada47eabb9c56", size = 2139585, upload-time = "2026-04-13T09:06:46.94Z" },
     { url = "https://files.pythonhosted.org/packages/a4/11/aa5089b941e85294b1d5d526840b18f0d4464f842d43d8999ce50ef881c1/pydantic_core-2.46.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:2f7e6a3752378a69fadf3f5ee8bc5fa082f623703eec0f4e854b12c548322de0", size = 2365925, upload-time = "2026-04-13T09:05:38.338Z" },
+]
+
+[[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[package.optional-dependencies]
+pycountry = [
+    { name = "pycountry", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
 ]
 
 [[package]]

--- a/asr-worker/uv.dist.lock
+++ b/asr-worker/uv.dist.lock
@@ -218,9 +218,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "caul", marker = "extra == 'cpu'", specifier = "==0.3.0" },
-    { name = "caul", marker = "extra == 'preprocessing'", specifier = "==0.3.0" },
-    { name = "caul", extras = ["nemo"], marker = "extra == 'inference'", specifier = "==0.3.0" },
+    { name = "caul", marker = "extra == 'cpu'", specifier = "==0.3.1" },
+    { name = "caul", marker = "extra == 'preprocessing'", specifier = "==0.3.1" },
+    { name = "caul", extras = ["nemo"], marker = "extra == 'inference'", specifier = "==0.3.1" },
     { name = "datashare-python", specifier = "~=0.5.0" },
     { name = "kaldialign", marker = "extra == 'inference'", specifier = "==0.9.3" },
     { name = "ml-dtypes", marker = "extra == 'inference'", specifier = "==0.5.4" },
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "caul"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "icij-common", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
@@ -343,9 +343,9 @@ dependencies = [
     { name = "torchaudio", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-asr-worker-gpu') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchcodec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/61/68461e52702b359815a433a602ee85be940c2b65d144ec464bb95c95acd6/caul-0.3.0.tar.gz", hash = "sha256:0c4645b1466ead71f8535d75a20f6184c829933a1f3f921bdb11b47854145fb1", size = 326458, upload-time = "2026-04-17T08:02:49.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/5a/16c3b0cd208086d8ae6d2f607c1d0006031a5ffb604f3491c666bd9cecb0/caul-0.3.1.tar.gz", hash = "sha256:cf1570736e6fc562fffe83d5b0bef5063db45a3c6305b9b3992f30202bf4fe84", size = 326458, upload-time = "2026-04-17T09:54:56.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/dc/73dbd87d99aab785e276d9cd0ee3ca6e43764eea00dd0b76476315047215/caul-0.3.0-py3-none-any.whl", hash = "sha256:278450d70881cce3eda714c4c8771d365209550be9eaf99bf085a55b2c4d0c27", size = 21796, upload-time = "2026-04-17T08:02:48.747Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7e/67082ea344cd09b814034271f66792d27e94b4a1882abe4cd29a60fe8922/caul-0.3.1-py3-none-any.whl", hash = "sha256:dcb76032c0b6358010b64fdfeba12eeab77606ee8ef048b47d321b59e959b69f", size = 21794, upload-time = "2026-04-17T09:54:55.258Z" },
 ]
 
 [package.optional-dependencies]

--- a/asr-worker/uv.lock
+++ b/asr-worker/uv.lock
@@ -218,9 +218,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "caul", marker = "extra == 'cpu'", specifier = "==0.3.0" },
-    { name = "caul", marker = "extra == 'preprocessing'", specifier = "==0.3.0" },
-    { name = "caul", extras = ["nemo"], marker = "extra == 'inference'", specifier = "==0.3.0" },
+    { name = "caul", marker = "extra == 'cpu'", specifier = "==0.3.1" },
+    { name = "caul", marker = "extra == 'preprocessing'", specifier = "==0.3.1" },
+    { name = "caul", extras = ["nemo"], marker = "extra == 'inference'", specifier = "==0.3.1" },
     { name = "datashare-python", editable = "../datashare-python" },
     { name = "kaldialign", marker = "extra == 'inference'", specifier = "==0.9.3" },
     { name = "ml-dtypes", marker = "extra == 'inference'", specifier = "==0.5.4" },
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "caul"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "icij-common", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
@@ -343,9 +343,9 @@ dependencies = [
     { name = "torchaudio", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-asr-worker-gpu') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchcodec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/61/68461e52702b359815a433a602ee85be940c2b65d144ec464bb95c95acd6/caul-0.3.0.tar.gz", hash = "sha256:0c4645b1466ead71f8535d75a20f6184c829933a1f3f921bdb11b47854145fb1", size = 326458, upload-time = "2026-04-17T08:02:49.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/5a/16c3b0cd208086d8ae6d2f607c1d0006031a5ffb604f3491c666bd9cecb0/caul-0.3.1.tar.gz", hash = "sha256:cf1570736e6fc562fffe83d5b0bef5063db45a3c6305b9b3992f30202bf4fe84", size = 326458, upload-time = "2026-04-17T09:54:56.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/dc/73dbd87d99aab785e276d9cd0ee3ca6e43764eea00dd0b76476315047215/caul-0.3.0-py3-none-any.whl", hash = "sha256:278450d70881cce3eda714c4c8771d365209550be9eaf99bf085a55b2c4d0c27", size = 21796, upload-time = "2026-04-17T08:02:48.747Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7e/67082ea344cd09b814034271f66792d27e94b4a1882abe4cd29a60fe8922/caul-0.3.1-py3-none-any.whl", hash = "sha256:dcb76032c0b6358010b64fdfeba12eeab77606ee8ef048b47d321b59e959b69f", size = 21794, upload-time = "2026-04-17T09:54:55.258Z" },
 ]
 
 [package.optional-dependencies]

--- a/asr-worker/uv.lock
+++ b/asr-worker/uv.lock
@@ -218,9 +218,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "caul", marker = "extra == 'cpu'", specifier = "==0.2.16" },
-    { name = "caul", marker = "extra == 'preprocessing'", specifier = "==0.2.16" },
-    { name = "caul", extras = ["nemo"], marker = "extra == 'inference'", specifier = "==0.2.16" },
+    { name = "caul", marker = "extra == 'cpu'", specifier = "==0.3.0" },
+    { name = "caul", marker = "extra == 'preprocessing'", specifier = "==0.3.0" },
+    { name = "caul", extras = ["nemo"], marker = "extra == 'inference'", specifier = "==0.3.0" },
     { name = "datashare-python", editable = "../datashare-python" },
     { name = "kaldialign", marker = "extra == 'inference'", specifier = "==0.9.3" },
     { name = "ml-dtypes", marker = "extra == 'inference'", specifier = "==0.5.4" },
@@ -329,21 +329,23 @@ wheels = [
 
 [[package]]
 name = "caul"
-version = "0.2.16"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "icij-common", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "kaldialign", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
+    { name = "langcodes", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "numpy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchaudio", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-asr-worker-cpu') or (extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchaudio", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-asr-worker-cpu' and extra != 'extra-10-asr-worker-gpu') or (sys_platform == 'darwin' and extra == 'extra-10-asr-worker-gpu') or (sys_platform == 'darwin' and extra != 'extra-10-asr-worker-cpu') or (extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchaudio", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-asr-worker-cpu') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchaudio", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-asr-worker-gpu') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
     { name = "torchcodec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/79/1ef53340a2c1fcc6b7f9e28182d8142b9e2806a9d54aaf2fa399f602701d/caul-0.2.16.tar.gz", hash = "sha256:9f5ac14b2cd721d3ac5d2d7e08fe495c851cb61acc51d634414efae2f68995a7", size = 319415, upload-time = "2026-04-10T08:08:23.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/61/68461e52702b359815a433a602ee85be940c2b65d144ec464bb95c95acd6/caul-0.3.0.tar.gz", hash = "sha256:0c4645b1466ead71f8535d75a20f6184c829933a1f3f921bdb11b47854145fb1", size = 326458, upload-time = "2026-04-17T08:02:49.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/42/8d6a1a6c42af5181f4ff12abf100052d01100f1be176808aab9e7930b0d6/caul-0.2.16-py3-none-any.whl", hash = "sha256:95f7d291e72dea39b56ce7c45d076dd8be0e80ee462f43840d296addea56a81e", size = 20621, upload-time = "2026-04-10T08:08:22.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/dc/73dbd87d99aab785e276d9cd0ee3ca6e43764eea00dd0b76476315047215/caul-0.3.0-py3-none-any.whl", hash = "sha256:278450d70881cce3eda714c4c8771d365209550be9eaf99bf085a55b2c4d0c27", size = 21796, upload-time = "2026-04-17T08:02:48.747Z" },
 ]
 
 [package.optional-dependencies]
@@ -1143,6 +1145,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/eb/5fcbbbf9a0e2c3a35effb88831a483345326bbc3a030a3b5b69aee647f84/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232", size = 59532, upload-time = "2026-03-09T13:15:47.047Z" },
     { url = "https://files.pythonhosted.org/packages/c3/9b/e17104555bb4db148fd52327feea1e96be4b88e8e008b029002c281a21ab/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a", size = 57420, upload-time = "2026-03-09T13:15:48.199Z" },
     { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892, upload-time = "2026-03-09T13:15:49.694Z" },
+]
+
+[[package]]
+name = "langcodes"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/75/f9edc5d72945019312f359e69ded9f82392a81d49c5051ed3209b100c0d2/langcodes-3.5.1.tar.gz", hash = "sha256:40bff315e01b01d11c2ae3928dd4f5cbd74dd38f9bd912c12b9a3606c143f731", size = 191084, upload-time = "2025-12-02T16:22:01.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/c1/d10b371bcba7abce05e2b33910e39c33cfa496a53f13640b7b8e10bb4d2b/langcodes-3.5.1-py3-none-any.whl", hash = "sha256:b6a9c25c603804e2d169165091d0cdb23934610524a21d226e4f463e8e958a72", size = 183050, upload-time = "2025-12-02T16:21:59.954Z" },
 ]
 
 [[package]]
@@ -2249,6 +2260,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycountry"
+version = "26.2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/061b9e7a48b85cfd69f33c33d2ef784a531c359399ad764243399673c8f5/pycountry-26.2.16.tar.gz", hash = "sha256:5b6027d453fcd6060112b951dd010f01f168b51b4bf8a1f1fc8c95c8d94a0801", size = 7711342, upload-time = "2026-02-17T03:42:52.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl", hash = "sha256:115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a", size = 8044600, upload-time = "2026-02-17T03:42:49.777Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2299,6 +2319,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/77/df8711ebb45910412f90d75198430fa1120f5618336b71fa00303601c5a4/pydantic_core-2.46.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1eae8d7d9b8c2a90b34d3d9014804dca534f7f40180197062634499412ea14e", size = 1953812, upload-time = "2026-04-13T09:05:40.293Z" },
     { url = "https://files.pythonhosted.org/packages/12/fe/14b35df69112bd812d6818a395eeab22eeaa2befc6f85bc54ed648430186/pydantic_core-2.46.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a95a2773680dd4b6b999d4eccdd1b577fd71c31739fb4849f6ada47eabb9c56", size = 2139585, upload-time = "2026-04-13T09:06:46.94Z" },
     { url = "https://files.pythonhosted.org/packages/a4/11/aa5089b941e85294b1d5d526840b18f0d4464f842d43d8999ce50ef881c1/pydantic_core-2.46.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:2f7e6a3752378a69fadf3f5ee8bc5fa082f623703eec0f4e854b12c548322de0", size = 2365925, upload-time = "2026-04-13T09:05:38.338Z" },
+]
+
+[[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[package.optional-dependencies]
+pycountry = [
+    { name = "pycountry", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra == 'extra-10-asr-worker-cpu' and extra == 'extra-10-asr-worker-gpu')" },
 ]
 
 [[package]]

--- a/datashare-python/datashare_python/conftest.py
+++ b/datashare-python/datashare_python/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncGenerator, Generator, Iterator, Sequence
 from pathlib import Path
 
 import aiohttp
+import nest_asyncio
 import pytest
 from elasticsearch._async.helpers import async_streaming_bulk
 from icij_common.es import DOC_ROOT_ID, ES_DOCUMENT_TYPE, ID, ESClient
@@ -296,3 +297,8 @@ async def all_done(task_client: DatashareTaskClient, not_done: list[str]) -> boo
                 return False
             not_done.remove(t_id)
     return True
+
+
+@pytest.fixture  # noqa: F405
+def typer_asyncio_patch() -> None:
+    nest_asyncio.apply()

--- a/datashare-python/tests/conftest.py
+++ b/datashare-python/tests/conftest.py
@@ -1,12 +1,6 @@
 import pytest  # noqa: I001
-import nest_asyncio
 from datashare_python.conftest import *  # noqa: F403
 from datashare_python.template import build_template_tarball
-
-
-@pytest.fixture  # noqa: F405
-def typer_asyncio_patch() -> None:
-    nest_asyncio.apply()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Addresses #12 

# Description

Expose available ASR models in GH release assets in the following format:

```json
{
  "bg": [
    "parakeet", "some_other_model"
  ],
  "cs": [
    "parakeet"
  ]
}

```

Where keys are [ISO_639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) codes or [IETF language](https://en.wikipedia.org/wiki/IETF_language_tag) tags

# Changes
## `asr-worker`

## Added
- added a `ASRModel.supported_languages(self) -> set[ASRLanguage]`
- added `ASRLanguage = IETFLanguage | LanguageAlpha2` where `IETFLanguage` are strings complying with local language codes and `LanguageAlpha2` are iso-2 codes

## Changed
- moved `VADModel` and `ASRModel` from `constants` to `objects`


