### PR TITLE
fix(.github): remove qemu emulation resulting in long builds

### DIFF
--- a/.github/workflows/publish_asr_worker.yml
+++ b/.github/workflows/publish_asr_worker.yml
@@ -46,9 +46,6 @@ jobs:
           tags: |
             type=match,pattern=asr-worker-(.*),group=1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -80,9 +77,6 @@ jobs:
           tags: |
             type=match,pattern=asr-worker-(.*),group=1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -113,9 +107,6 @@ jobs:
           images: icij/asr-transcription-inference-gpu-worker
           tags: |
             type=match,pattern=asr-worker-(.*),group=1
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
# Description

For ASR worker we're not building images for ARM since, we hence disable QEMU and multiplatform build to avoid the notoriously awful QEMU overheda.

# Changes
## `.github` 
- removed qemu emulation for all asr related image build