### PR TITLE
fix(workflows-worker): temporarily make asr-worker mandatorily depend on caul to run workflow

### DIFF
--- a/workers/asr-worker/pyproject.toml
+++ b/workers/asr-worker/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 requires-python = ">=3.11.0, <3.13"
 dependencies = [
   "datashare-python~=0.8.6",
+  "caul==0.5.8",
 ]
 
 [project.scripts]
@@ -18,10 +19,8 @@ asr-worker = "asr_worker.__main__:main"
 
 [project.optional-dependencies]
 cli = [
-  "caul==0.5.8",
 ]
 cpu = [
-  "caul==0.5.8",
   "torch==2.10.0",
   "torchaudio==2.10.0",
   "torchcodec==0.10.0",
@@ -33,14 +32,12 @@ gpu = [
   "torchcodec==0.10.0+cu129; sys_platform == 'linux'",
 ]
 inference = [
-  "caul[nemo]==0.5.8",
   "kaldialign==0.9.3",
   "ml-dtypes==0.5.4",
   "numpy==2.3.0",
   "pyarrow==20.0.0",
 ]
 preprocessing = [
-  "caul==0.5.8",
 ]
 
 [project.entry-points."datashare.workflows"]


### PR DESCRIPTION
# Description

Tthe `workflows-worker` was made to run all workflows in a single worker.

For now `asr-worker` depends on `caul` only optionally for inference, however there's a hidden dependency through the `caul.objects` which are used for ser/deser.

# Changes

## `asr-worker`
### Changed
- temporarily made `asr-worker` depend on caul mandatorily
